### PR TITLE
feat: add dvc clean up pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import io
 import shutil
 from pathlib import Path
 from unittest.mock import patch
+from dvc.repo import Repo
 
 import pytest
 
@@ -23,3 +24,9 @@ def captured_print():
     with io.StringIO() as output:
         with patch("builtins.print", new=lambda msg: output.write(f"{msg}\n")):
             yield output
+
+
+@pytest.fixture(scope="function")
+def clean_up_dvc():
+    yield
+    Repo(".").pull(force=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-def test_main(dvc_path, captured_print: io.StringIO) -> None:
+def test_main(dvc_path, captured_print: io.StringIO, clean_up_dvc: None) -> None:
     # Given
     import sys
-
-    from dvc.api import DVCFileSystem
 
     from data_cliff.cli import main
 
@@ -36,9 +34,6 @@ def test_main(dvc_path, captured_print: io.StringIO) -> None:
 
     # Then
     assert captured_print.getvalue() == expected_output
-
-    # Finally
-    DVCFileSystem(rev="HEAD").get(str(file), str(file))
 
 
 def _add_line_to_path(file: Path) -> None:

--- a/tests/test_data_cliff.py
+++ b/tests/test_data_cliff.py
@@ -22,11 +22,9 @@ def test_retrieves_file(dvc_path: Path, tmp_path: Path) -> None:
 
 
 def test_compare_staged_change_on_text_file(
-    dvc_path: Path, captured_print: io.StringIO
+    dvc_path: Path, captured_print: io.StringIO, clean_up_dvc: None
 ) -> None:
     # Given
-    from dvc.api import DVCFileSystem
-
     from data_cliff.data_cliff import compare
 
     file = dvc_path / "dir" / "file.json"
@@ -46,22 +44,17 @@ def test_compare_staged_change_on_text_file(
         " }\n"
     )
 
-    try:
-        # When
-        compare("HEAD", None, str(file))
+    # When
+    compare("HEAD", None, str(file))
 
-        # Then
-        assert captured_print.getvalue() == expected_output
-    finally:
-        DVCFileSystem(rev="HEAD").get(str(file), str(file))
+    # Then
+    assert captured_print.getvalue() == expected_output
 
 
 def test_compare_staged_change_on_binary_file(
-    dvc_path, captured_print: io.StringIO
+    dvc_path, captured_print: io.StringIO, clean_up_dvc: None
 ) -> None:
     # Given
-    from dvc.api import DVCFileSystem
-
     from data_cliff.data_cliff import compare
 
     file = dvc_path / "dir" / "binary"
@@ -75,22 +68,17 @@ def test_compare_staged_change_on_binary_file(
         "b/tests/test_dvc_data/local_data/dir/binary differ\n"
     )
 
-    try:
-        # When
-        compare("HEAD", None, str(file))
+    # When
+    compare("HEAD", None, str(file))
 
-        # Then
-        assert captured_print.getvalue() == expected_output
-    finally:
-        DVCFileSystem(rev="HEAD").get(str(file), str(file))
+    # Then
+    assert captured_print.getvalue() == expected_output
 
 
 def test_compare_staged_change_on_folder(
-    dvc_path: Path, captured_print: io.StringIO
+    dvc_path: Path, captured_print: io.StringIO, clean_up_dvc: None
 ) -> None:
     # Given
-    from dvc.api import DVCFileSystem
-
     from data_cliff.data_cliff import compare
 
     folder = dvc_path / "dir"
@@ -109,14 +97,12 @@ def test_compare_staged_change_on_folder(
         '\x1b[92m+    "new_key": "new_value"\x1b[00m\n'
         " }\n"
     )
-    try:
-        # When
-        compare("HEAD", None, str(folder))
 
-        # Then
-        assert captured_print.getvalue() == expected_output
-    finally:
-        DVCFileSystem(rev="HEAD").get(str(folder), str(folder.parent), recursive=True)
+    # When
+    compare("HEAD", None, str(folder))
+
+    # Then
+    assert captured_print.getvalue() == expected_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #40.

Not sure if we should keep the `autouse` here, some tests do not mess with dvc (like the ones testing the arg parsing). But I deduced you'd want it to be automatic anyways from 

> (run a dvc pull --force after **each** test)
